### PR TITLE
fix: update explorer url in withdrawal service

### DIFF
--- a/src/services/bridge/withdraw.ts
+++ b/src/services/bridge/withdraw.ts
@@ -38,8 +38,7 @@ export async function executeWithdraw(params: WithdrawParams): Promise<WithdrawR
     const receipt = await tx.wait();
     const txHash = receipt.hash;
 
-    // TODO: Update explorer URL
-    const explorerUrl = `https://explorer.testnet.viablockchain.xyz/tx/${txHash}`;
+    const explorerUrl = `https://testnet.blockscout.onvia.org/tx/${txHash}`;
 
     return {
       txHash,


### PR DESCRIPTION
Since people are testing lately, useful to have the right explorer link 