### PR TITLE
UX network banner component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.0.1",
+    "@fortawesome/free-brands-svg-icons": "^7.0.1",
+    "@fortawesome/react-fontawesome": "^3.0.2",
     "@hookform/resolvers": "^4.1.3",
     "@radix-ui/react-dropdown-menu": "^2.1.7",
     "@radix-ui/react-label": "^2.1.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import '@fortawesome/fontawesome-svg-core/styles.css'
+import { config } from '@fortawesome/fontawesome-svg-core'
+config.autoAddCss = false
 import { Toaster } from "sonner";
 import Header from "@/components/header";
 import Footer from "@/components/footer";

--- a/src/components/deposit-form.tsx
+++ b/src/components/deposit-form.tsx
@@ -7,11 +7,10 @@ import * as z from "zod";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { ArrowRight, ExternalLink, Loader2 } from "lucide-react";
+import { ExternalLink, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { executeDeposit } from "@/services/bridge/deposit";
 import { getBitcoinBalance } from "@/services/bitcoin/balance";
-import Image from "next/image";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useWalletStore } from "@/store/wallet-store";
 import { isAddress } from "ethers";
@@ -19,6 +18,7 @@ import { SYSTEM_CONTRACTS_ADDRESSES_RANGE, L1_BTC_DECIMALS, FEE_RESERVE_BTC, MIN
 import { cn } from "@/lib/utils";
 import { BRIDGE_CONFIG } from "@/services/config";
 import { FormAmountSlider } from "@/components/form-amount-slider";
+import NetworkRouteBanner from "@/components/ui/network-route-banner";
 
 
 interface DepositFormProps {
@@ -287,44 +287,7 @@ export default function DepositForm({ bitcoinAddress, bitcoinPublicKey, onTransa
 
   return (
     <div className="w-full max-w-md min-w-[300px] sm:min-w-[360px] mx-auto">
-      <div className="flex items-center justify-between bg-muted/50 rounded-lg p-3 mb-4">
-        <div className="flex items-center gap-2">
-          <Image
-            src="/bitcoin-logo.svg"
-            alt="Bitcoin"
-            width={20}
-            height={20}
-            className="text-amber-500"
-          />
-          <div className="flex flex-col">
-            <span className="text-sm font-medium">Bitcoin</span>
-            <span className="text-xs text-muted-foreground">Network</span>
-          </div>
-        </div>
-        <div className="flex flex-col items-center gap-1">
-          <div className="flex items-center gap-1 px-2 py-1 bg-primary/5 rounded-full">
-            <Image
-              src="/bitcoin-logo.svg"
-              alt="BTC"
-              width={14}
-              height={14}
-              className="text-amber-500"
-            />
-            <span className="text-xs font-medium">BTC</span>
-          </div>
-          <ArrowRight className="h-5 w-10 text-primary" strokeWidth={2.5} />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-5 w-5 rounded-full bg-primary/10 flex items-center justify-center">
-            <div className="h-3 w-3 rounded-full bg-primary" />
-          </div>
-          <div className="flex flex-col">
-            <span className="text-sm font-medium">VIA</span>
-            <span className="text-xs text-muted-foreground">Network</span>
-          </div>
-        </div>
-      </div>
-
+      <NetworkRouteBanner direction="deposit" />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           <FormField
@@ -485,5 +448,3 @@ export default function DepositForm({ bitcoinAddress, bitcoinPublicKey, onTransa
     </div>
   );
 }
-
-

--- a/src/components/ui/network-route-banner.tsx
+++ b/src/components/ui/network-route-banner.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Image from "next/image";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Direction = "deposit" | "withdraw";
+type Network = "bitcoin" | "via";
+
+interface NetworkRouteBannerProps {
+  direction: Direction;
+  tokenSymbol?: string;
+  tokenIconSrc?: string;
+  className?: string;
+}
+
+function ViaDot() {
+  return (
+    <div className="h-5 w-5 rounded-full bg-primary/10 flex items-center justify-center">
+      <div className="h-3 w-3 rounded-full bg-primary" />
+    </div>
+  );
+}
+
+function Side({ network }: { network: Network }) {
+  if (network === "bitcoin") {
+    return (
+      <div className="flex items-center gap-2">
+        <Image  src="/bitcoin-logo.svg"  alt="Bitcoin"  width={20}  height={20}  className="text-amber-500"/>
+        <div className="flex flex-col">
+          <span className="text-sm font-medium">Bitcoin</span>
+          <span className="text-xs text-muted-foreground">Network</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <ViaDot />
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">VIA</span>
+        <span className="text-xs text-muted-foreground">Network</span>
+      </div>
+    </div>
+  );
+}
+
+export default function NetworkRouteBanner({direction, tokenSymbol = "BTC", tokenIconSrc = "/bitcoin-logo.svg", className,}: NetworkRouteBannerProps) {
+  const [left, right]: [Network, Network] =
+    direction === "deposit" ? ["bitcoin", "via"] : ["via", "bitcoin"];
+
+  return (
+    <div className={cn("flex items-center justify-between bg-muted/50 rounded-lg p-3 mb-4", className)}>
+      <Side network={left} />
+      <div className="flex flex-col items-center gap-1">
+        <div className="flex items-center gap-1 px-2 py-1 bg-primary/5 rounded-full">
+          <Image  src={tokenIconSrc}  alt={tokenSymbol}  width={14}  height={14}  className="text-amber-500"/>
+          <span className="text-xs font-medium">{tokenSymbol}</span>
+        </div>
+        <ArrowRight className="h-5 w-10 text-primary" strokeWidth={2.5} />
+      </div>
+      <Side network={right} />
+    </div>
+  );
+}

--- a/src/components/ui/network-route-banner.tsx
+++ b/src/components/ui/network-route-banner.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import Image from "next/image";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faViacoin, faBitcoin } from "@fortawesome/free-brands-svg-icons";
 
 type Direction = "deposit" | "withdraw";
 type Network = "bitcoin" | "via";
@@ -10,14 +11,13 @@ type Network = "bitcoin" | "via";
 interface NetworkRouteBannerProps {
   direction: Direction;
   tokenSymbol?: string;
-  tokenIconSrc?: string;
   className?: string;
 }
 
-function ViaDot() {
+function ViaBadge() {
   return (
     <div className="h-5 w-5 rounded-full bg-primary/10 flex items-center justify-center">
-      <div className="h-3 w-3 rounded-full bg-primary" />
+      <FontAwesomeIcon icon={faViacoin} className="text-primary" style={{ width: 20, height: 20}} />
     </div>
   );
 }
@@ -26,7 +26,7 @@ function Side({ network }: { network: Network }) {
   if (network === "bitcoin") {
     return (
       <div className="flex items-center gap-2">
-        <Image  src="/bitcoin-logo.svg"  alt="Bitcoin"  width={20}  height={20}  className="text-amber-500"/>
+        <FontAwesomeIcon icon={faBitcoin} className="text-amber-500" style={{ width: 20, height: 20 }} />
         <div className="flex flex-col">
           <span className="text-sm font-medium">Bitcoin</span>
           <span className="text-xs text-muted-foreground">Network</span>
@@ -37,7 +37,7 @@ function Side({ network }: { network: Network }) {
 
   return (
     <div className="flex items-center gap-2">
-      <ViaDot />
+      <ViaBadge />
       <div className="flex flex-col">
         <span className="text-sm font-medium">VIA</span>
         <span className="text-xs text-muted-foreground">Network</span>
@@ -46,19 +46,20 @@ function Side({ network }: { network: Network }) {
   );
 }
 
-export default function NetworkRouteBanner({direction, tokenSymbol = "BTC", tokenIconSrc = "/bitcoin-logo.svg", className,}: NetworkRouteBannerProps) {
+export default function NetworkRouteBanner({direction, tokenSymbol = "BTC", className,}: NetworkRouteBannerProps) {
   const [left, right]: [Network, Network] =
     direction === "deposit" ? ["bitcoin", "via"] : ["via", "bitcoin"];
+  const Arrow = direction === "deposit" ? ArrowRight : ArrowLeft;
 
   return (
     <div className={cn("flex items-center justify-between bg-muted/50 rounded-lg p-3 mb-4", className)}>
       <Side network={left} />
       <div className="flex flex-col items-center gap-1">
         <div className="flex items-center gap-1 px-2 py-1 bg-primary/5 rounded-full">
-          <Image  src={tokenIconSrc}  alt={tokenSymbol}  width={14}  height={14}  className="text-amber-500"/>
+          <FontAwesomeIcon icon={faBitcoin} className="text-amber-500" style={{ width: 14, height: 14 }} />
           <span className="text-xs font-medium">{tokenSymbol}</span>
         </div>
-        <ArrowRight className="h-5 w-10 text-primary" strokeWidth={2.5} />
+        <Arrow className="h-5 w-10 text-primary" strokeWidth={2.5} />
       </div>
       <Side network={right} />
     </div>

--- a/src/components/withdraw-form.tsx
+++ b/src/components/withdraw-form.tsx
@@ -7,10 +7,9 @@ import * as z from "zod";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { ArrowRight, Loader2, ExternalLink, HelpCircle } from "lucide-react";
+import { Loader2, ExternalLink, HelpCircle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { toast } from "sonner";
-import Image from "next/image";
 import { executeWithdraw } from "@/services/bridge/withdraw";
 import { useWalletStore } from "@/store/wallet-store";
 import { getViaBalance } from "@/services/via/balance";
@@ -19,6 +18,7 @@ import { toL1Amount } from "@/helpers";
 import { FormAmountSlider } from "@/components/form-amount-slider";
 import { MIN_WITHDRAW_BTC, MIN_WITHDRAW_SATS } from "@/services/constants";
 import { useDebounce } from "@/hooks/useDebounce";
+import NetworkRouteBanner from "@/components/ui/network-route-banner";
 
 interface WithdrawFormProps {
   viaAddress: string | null
@@ -250,43 +250,7 @@ export default function WithdrawForm({ viaAddress, onTransactionSubmitted }: Wit
 
   return (
     <div className="w-full max-w-md min-w-[300px] sm:min-w-[360px] mx-auto">
-      <div className="flex items-center justify-between bg-muted/50 rounded-lg p-3 mb-4">
-        <div className="flex items-center gap-2">
-          <div className="h-5 w-5 rounded-full bg-primary/10 flex items-center justify-center">
-            <div className="h-3 w-3 rounded-full bg-primary" />
-          </div>
-          <div className="flex flex-col">
-            <span className="text-sm font-medium">VIA</span>
-            <span className="text-xs text-muted-foreground">Network</span>
-          </div>
-        </div>
-        <div className="flex flex-col items-center gap-1">
-          <div className="flex items-center gap-1 px-2 py-1 bg-primary/5 rounded-full">
-            <Image
-              src="/bitcoin-logo.svg"
-              alt="BTC"
-              width={14}
-              height={14}
-              className="text-amber-500"
-            />
-            <span className="text-xs font-medium">BTC</span>
-          </div>
-          <ArrowRight className="h-5 w-10 text-primary" strokeWidth={2.5} />
-        </div>
-        <div className="flex items-center gap-2">
-          <Image
-            src="/bitcoin-logo.svg"
-            alt="Bitcoin"
-            width={20}
-            height={20}
-            className="text-amber-500"
-          />
-          <div className="flex flex-col">
-            <span className="text-sm font-medium">Bitcoin</span>
-            <span className="text-xs text-muted-foreground">Network</span>
-          </div>
-        </div>
-      </div>
+      <NetworkRouteBanner direction="withdraw" />
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">


### PR DESCRIPTION
* old 
<img width="654" height="440" alt="image" src="https://github.com/user-attachments/assets/662d0f1a-c17b-4c28-8a75-b8afa984c4f9" />

* new 
<img width="656" height="405" alt="image" src="https://github.com/user-attachments/assets/1ea6397a-1459-4099-970f-4fbbc0cf6991" />

Logos fixed
The arrow on withdrawal was pointing in the wrong direction 

The route banner into a component, so we won't have to edit on both the deposit and withdraw side
This shouldn't break anything 